### PR TITLE
pass on options if $path is an array

### DIFF
--- a/index.php
+++ b/index.php
@@ -26,7 +26,7 @@ if (! function_exists('mix')) {
             $assets = [];
 
             foreach($path as $p) {
-                $assets[] = mix($p);
+                $assets[] = mix($p, $options);
             }
 
             return implode(PHP_EOL, $assets) . PHP_EOL;


### PR DESCRIPTION
options get lost when passing an array of paths to `mix()`

e.g.:
```php
echo mix([
    '/js/manifest.js',
    '/js/vendor.js',
    '@autojs'
], ['defer' => true]);
```